### PR TITLE
Buildfix: pin rspec-its; simplify podman install (resolves #597)

### DIFF
--- a/docker-api.gemspec
+++ b/docker-api.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'multi_json'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3.0'
-  gem.add_development_dependency 'rspec-its'
+  gem.add_development_dependency 'rspec-its', '~> 1'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'single_cov'
   gem.add_development_dependency 'webmock'

--- a/script/install_podman.sh
+++ b/script/install_podman.sh
@@ -1,12 +1,5 @@
 #!/bin/sh
 set -ex
 
-. /etc/os-release
-
-curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
-
-echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" > /etc/apt/sources.list.d/podman.list
-
 apt-get update
-
 apt-get install -y podman


### PR DESCRIPTION
- Pins rspec-its to 1.x
- Removes unnecessary setup steps for Ubuntu 20.10+ from ./scripts/install_podman.sh