### PR TITLE
Send :read_timeout when streaming events (#584)

### DIFF
--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -137,24 +137,24 @@ class Docker::Connection
   end
 
 private
-  # Given an HTTP method, path, optional query, extra options, and block,
-  # compiles a request.
+
   def compile_request_params(http_method, path, query = nil, opts = nil, &block)
-    query ||= {}
     opts ||= {}
-    headers = opts.delete(:headers) || {}
-    content_type = opts[:body].nil? ?  'text/plain' : 'application/json'
-    user_agent = "Swipely/Docker-API #{Docker::VERSION}"
+    query ||= opts.delete(:query) || {}
+
+    default_headers = {
+      'Content-Type' => opts[:body].nil? ? 'text/plain' : 'application/json',
+      'User-Agent' => "Swipely/Docker-API #{Docker::VERSION}",
+    }
+    headers = default_headers.merge(opts.delete(:headers) || {})
+
     {
-      :method        => http_method,
-      :path          => path,
-      :query         => query,
-      :headers       => { 'Content-Type' => content_type,
-                          'User-Agent'   => user_agent,
-                        }.merge(headers),
-      :expects       => (200..204).to_a << 301 << 304,
-      :idempotent    => http_method == :get,
-      :request_block => block,
-    }.merge(opts).reject { |_, v| v.nil? }
+      method: http_method,
+      path: path,
+      headers:,
+      query:,
+      expects: (200..204).to_a << 301 << 304,
+      idempotent: http_method == :get,
+    }.merge(opts).tap { |params| params[:request_block] = block if block }
   end
 end

--- a/lib/docker/connection.rb
+++ b/lib/docker/connection.rb
@@ -151,8 +151,8 @@ private
     {
       method: http_method,
       path: path,
-      headers:,
-      query:,
+      headers: headers,
+      query: query,
       expects: (200..204).to_a << 301 << 304,
       idempotent: http_method == :get,
     }.merge(opts).tap { |params| params[:request_block] = block if block }

--- a/spec/docker/event_spec.rb
+++ b/spec/docker/event_spec.rb
@@ -117,7 +117,7 @@ describe Docker::Event do
           # Filter to avoid unexpected Docker events interfering with timeout behavior
           query: { filters: { container: [SecureRandom.uuid] }.to_json },
           # Use [] to differentiate between explicit nil and not providing an arg (falling back to the default)
-          read_timeout:,
+          read_timeout: read_timeout,
         }.reject { |_, v| v.empty? rescue false }
 
         Docker::Event.stream(opts) do |event|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,10 @@ RSpec.shared_context "local paths" do
 end
 
 module SpecHelpers
+  def skip_slow_test
+    skip "Disabled because ENV['RUN_SLOW_TESTS'] not set" unless ENV['RUN_SLOW_TESTS']
+  end
+
   def skip_without_auth
     skip "Disabled because of missing auth" if ENV['DOCKER_API_USER'] == 'debbie_docker'
   end


### PR DESCRIPTION
- Corrects a bug in `Docker::Connection.compile_request_params` that incorrectly stripped out `read_timeout` when it was nil.
- Sets `Docker::Event.stream` to skip timeouts by default.
- Sets `Docker::Event.stream` to avoid automatically retrying timeout-related events by default.
- Adds timeout-related event streaming tests. A particularly slow (60s+) test can be enabled by setting `RUN_SLOW_TESTS=1` in the testing environment.