### PR TITLE
Require Ruby 3.x

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -18,11 +18,7 @@ jobs:
           - 3.3
           - 3.2
           - 3.1
-          - '3.0'
-          - 2.7
-          - 2.6
-          - 2.5
-          - 2.4
+          - '3.0' # quoted to avoid interpretation as "3"
         docker_version:
           - ':26.'
           - ':27.'


### PR DESCRIPTION
Removes Ruby 2.x from the GitHub Actions pipeline, effectively dropping the requirement to support those versions. This allows new / refactored code to use modern Ruby idioms.